### PR TITLE
Change the order of the processing.

### DIFF
--- a/CCXWebview/CCXWebview/proj.android/src/org/go3k/ccxwebview/CCXWebview.java
+++ b/CCXWebview/CCXWebview/proj.android/src/org/go3k/ccxwebview/CCXWebview.java
@@ -108,8 +108,8 @@ public class CCXWebview extends Cocos2dxActivity{
 
     	this.runOnUiThread(new Runnable() {
             public void run() {
-            	m_webView.destroy();
             	m_webLayout.removeView(m_webView);
+            	m_webView.destroy();
             }
         });
     }


### PR DESCRIPTION
When WebView is closed on Android, An error has occurred.

03-18 21:20:27.254: E/webview(32078): Error: WebView.destroy() called while still attached!

So, I changed the order of processing.

Sorry for my bad english.
